### PR TITLE
change variable name from lookedAt to review in triage.js getRequest return

### DIFF
--- a/triage.js
+++ b/triage.js
@@ -46,7 +46,7 @@ function getRequest(settings, message) {
   let bot = message.subtype === 'bot_message';                // bot posts
   let priority = settings.pending.emojis.indexOf(emoji);      // display order
 
-  return { bot, priority, emoji, looked_at, addressed, pending, id, message };
+  return { bot, priority, emoji, review, addressed, pending, id, message };
 }
 
 


### PR DESCRIPTION
Change return in triage.js to `review` instead of `lookedAt` which is not defined. 